### PR TITLE
Added cacheable to aura method

### DIFF
--- a/force-app/main/default/classes/FeatureFlags.cls
+++ b/force-app/main/default/classes/FeatureFlags.cls
@@ -53,7 +53,7 @@ public with sharing class FeatureFlags implements IFeatureFlags {
         return result;
     }
 
-    @AuraEnabled
+    @AuraEnabled(cacheable=true)
     public static Boolean lwcEvaluate(String featureName){
         return new FeatureFlags().evaluate(featureName).isEnabled();
     }


### PR DESCRIPTION
Since flags are assumed as almost-static values, they can be cached on the frontend side